### PR TITLE
Show level success dialog after time is up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Description Patterns-and-Frameworks
+# Beschreibung Patterns-and-Frameworks
 Semesterprojekt zur Entwicklung eines auf Java/JavaFX basierenden Computerspiels.
 
 # Development
-## Running the client
+## Client starten
 Der Client kann über die Main-Class `StartApplication` gestartet werden.
 
 ### Intellij
@@ -12,20 +12,21 @@ und bei "Import module from existing model" maven auswählen.
 Bei der Run Configuration kann dann `frontend` als Modul gewählt werden, der Pfad zur Main Application
 ist `puf.frisbee.frontend.StartApplication`.
 
-## Running the server
+## Server starten
 TBD
 
-## Running the database
+## Datenbank starten
 TBD
 
-## Running the tests
+## Tests starten
 TBD
 
-# Architectural decisions 
-TBD
+# Architekturentscheidungen
+Wir benutzen das MVVM-Pattern ohne Framework.
 
-## Database System
+## Datenbank
 PostgreSQL: https://www.postgresql.org
 
-## Frameworks
+## Frameworks und libraries
 * Hibernate ORM: https://hibernate.org/orm/
+* Material Design Library: http://www.jfoenix.com/

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -38,6 +38,11 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.jfoenix</groupId>
+            <artifactId>jfoenix</artifactId>
+            <version>9.0.10</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/frontend/src/main/java/module-info.java
+++ b/frontend/src/main/java/module-info.java
@@ -2,10 +2,14 @@ module puf.frisbee.frontend {
     requires javafx.controls;
     requires javafx.fxml;
     requires javafx.graphics;
+    requires com.jfoenix;
 
 
     opens puf.frisbee.frontend to javafx.fxml;
     exports puf.frisbee.frontend;
+
+    opens puf.frisbee.frontend.core to javafx.fxml;
+    exports puf.frisbee.frontend.core;
 
     opens puf.frisbee.frontend.model to javafx.fxml;
     exports puf.frisbee.frontend.model;

--- a/frontend/src/main/java/puf/frisbee/frontend/core/ViewHandler.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/core/ViewHandler.java
@@ -26,7 +26,7 @@ public class ViewHandler {
      * Loads the view for a level.
      * @param level that should be loaded
      */
-    private void openLevelView(int level) {
+    public void openLevelView(int level) {
         FXMLLoader loader = new FXMLLoader();
 
         switch(level) {
@@ -38,8 +38,8 @@ public class ViewHandler {
         try {
             Parent root = loader.load();
             LevelView levelView = loader.getController();
-            levelView.init(viewModelFactory.getLevelViewModel());
-            this.stage.setTitle("Frisbee");
+            levelView.init(viewModelFactory.getLevelViewModel(), this);
+            this.stage.setTitle("Frisbee Level " + level);
             Scene scene = new Scene(root, 1280, 720);
             scene.getStylesheets().add(getClass().getResource("/puf/frisbee/frontend/css/level.css").toExternalForm());
             this.stage.setScene(scene);

--- a/frontend/src/main/java/puf/frisbee/frontend/model/Level.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Level.java
@@ -1,0 +1,20 @@
+package puf.frisbee.frontend.model;
+
+public interface Level {
+    /**
+     * Returns the current level that a team can play.
+     * @return current level as integer
+     */
+    int getCurrentLevel();
+
+    /**
+     * Updates the current level to the next level.
+     */
+    void updateCurrentLevel();
+
+    /**
+     * Returns the countdown for a level in seconds.
+     * @return countdown in seconds
+     */
+    int getCountdown();
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/model/LevelModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/LevelModel.java
@@ -1,16 +1,19 @@
 package puf.frisbee.frontend.model;
 
-// TODO: add interface for class
-public class LevelModel {
-    private int countdownSeconds;
-
-    public void setCountdown(int countdownSeconds)
-    {
-        this.countdownSeconds = countdownSeconds;
-    }
+public class LevelModel implements Level {
+    // TODO: get this from the server
+    private int countdownInSeconds = 10;
+    private int currentLevel = 1;
 
     public int getCountdown() {
-        return this.countdownSeconds;
+        return this.countdownInSeconds;
     }
 
+    public int getCurrentLevel() {
+        return this.currentLevel;
+    }
+
+    public void updateCurrentLevel() {
+        currentLevel++;
+    }
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/view/LevelView.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/view/LevelView.java
@@ -1,11 +1,22 @@
 package puf.frisbee.frontend.view;
 
+import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.input.MouseEvent;
+import com.jfoenix.controls.JFXButton;
+import com.jfoenix.controls.JFXDialog;
+import javafx.scene.layout.StackPane;
+import puf.frisbee.frontend.core.ViewHandler;
 import puf.frisbee.frontend.viewmodel.LevelViewModel;
 
 public class LevelView {
+    @FXML
+    private StackPane modalRoot;
+
+    @FXML
+    private JFXDialog levelSuccessDialog;
+
     @FXML
     private Label labelCharacterLeft;
 
@@ -18,13 +29,27 @@ public class LevelView {
     @FXML
     private Label labelCountdown;
 
-    private LevelViewModel levelViewModel;
+    @FXML
+    private Label labelLevelSuccess;
 
-    public void init(LevelViewModel levelViewModel) {
-        // also later we will have the ViewHandler as dependency, so we can load different views when clicking a button
-        // (e.g. after confirming game over)
+    @FXML
+    private JFXButton buttonLevelContinue;
+
+
+    private LevelViewModel levelViewModel;
+    private ViewHandler viewHandler;
+
+    public void init(LevelViewModel levelViewModel, ViewHandler viewHandler) {
         this.levelViewModel = levelViewModel;
-        this.labelCountdown.textProperty().bind(levelViewModel.getCountdownProperty());
+        this.viewHandler = viewHandler;
+
+        this.labelCountdown.textProperty().bind(this.levelViewModel.getLabelCountdownProperty());
+        this.labelLevelSuccess.textProperty().bind(this.levelViewModel.getLabelLevelSuccessProperty());
+        this.buttonLevelContinue.textProperty().bind(this.levelViewModel.getButtonLevelContinueTextProperty());
+
+        this.levelSuccessDialog.setTransitionType(JFXDialog.DialogTransition.TOP);
+        this.levelSuccessDialog.setDialogContainer(this.modalRoot);
+        this.levelSuccessDialog.visibleProperty().bind(this.levelViewModel.getLevelSuccessDialogOpenProperty());
     }
 
     @FXML
@@ -40,5 +65,11 @@ public class LevelView {
     @FXML
     private void handleFrisbeeClicked(MouseEvent event) {
         labelFrisbee.setText("Los geht's!");
+    }
+
+    @FXML
+    private void handleLevelContinueClicked(ActionEvent event) {
+        levelViewModel.continueLevel();
+        this.viewHandler.openLevelView(this.levelViewModel.getLevel());
     }
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/LevelViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/LevelViewModel.java
@@ -2,8 +2,13 @@ package puf.frisbee.frontend.viewmodel;
 
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.util.Duration;
@@ -11,38 +16,61 @@ import puf.frisbee.frontend.model.LevelModel;
 
 public class LevelViewModel {
 	private LevelModel levelModel;
-	private StringProperty countdown;
+	private StringProperty labelCountdown;
+	private StringProperty labelLevelSuccess;
+	private StringProperty buttonLevelContinueText;
 	private int second;
+	private BooleanProperty showLevelSuccessDialog;
 
 
 	public LevelViewModel(LevelModel levelModel) {
 		this.levelModel = levelModel;
-		levelModel.setCountdown(30);
-		this.countdown = new SimpleStringProperty();
+		this.labelCountdown = new SimpleStringProperty();
+		this.labelLevelSuccess = new SimpleStringProperty();
+		this.buttonLevelContinueText = new SimpleStringProperty();
+		this.showLevelSuccessDialog = new SimpleBooleanProperty(false);
 		this.startCountdown();
 	}
 
 	private void startCountdown() {
 		this.second = levelModel.getCountdown();
 		Timeline timeline = new Timeline();
-		timeline.getKeyFrames().add(new KeyFrame(Duration.seconds(1), new EventHandler<ActionEvent>() {
-			@Override
-			public void handle(ActionEvent actionEvent) {
-				countdown.setValue(Integer.toString(second));
-				second--;
+		timeline.getKeyFrames().add(new KeyFrame(Duration.seconds(1), actionEvent -> {
+			labelCountdown.setValue(Integer.toString(second));
+			second--;
 
-				if (second < 0) {
-					timeline.stop();
-					countdown.setValue("Time over");
-					// TODO: set flag for pop up if countdown is 0
-				}
+			if (second < 0) {
+				timeline.stop();
+				labelCountdown.setValue("Time over");
+				showLevelSuccessDialog.setValue(true);
 			}
 		}));
 		timeline.setCycleCount(Timeline.INDEFINITE);
 		timeline.play();
 	}
 
-	public StringProperty getCountdownProperty() {
-		return this.countdown;
+	public void continueLevel() {
+		this.levelModel.updateCurrentLevel();
+		this.showLevelSuccessDialog.setValue(false);
+	}
+
+	public int getLevel() {
+		return this.levelModel.getCurrentLevel();
+	}
+
+	public StringProperty getLabelCountdownProperty() {
+		return this.labelCountdown;
+	}
+	public StringProperty getLabelLevelSuccessProperty() {
+		this.labelLevelSuccess.setValue("Level " + this.levelModel.getCurrentLevel() + " geschafft!");
+		return this.labelLevelSuccess;
+	}
+	public StringProperty getButtonLevelContinueTextProperty() {
+		this.buttonLevelContinueText.setValue("Weiter zu Level " + this.levelModel.getCurrentLevel());
+		return this.buttonLevelContinueText;
+	}
+
+	public BooleanProperty getLevelSuccessDialogOpenProperty() {
+		return this.showLevelSuccessDialog;
 	}
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/LevelViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/LevelViewModel.java
@@ -66,7 +66,8 @@ public class LevelViewModel {
 		return this.labelLevelSuccess;
 	}
 	public StringProperty getButtonLevelContinueTextProperty() {
-		this.buttonLevelContinueText.setValue("Weiter zu Level " + this.levelModel.getCurrentLevel());
+		int nextLevel = this.levelModel.getCurrentLevel() + 1;
+		this.buttonLevelContinueText.setValue("Weiter zu Level " + nextLevel);
 		return this.buttonLevelContinueText;
 	}
 

--- a/frontend/src/main/resources/puf/frisbee/frontend/view/LevelView.fxml
+++ b/frontend/src/main/resources/puf/frisbee/frontend/view/LevelView.fxml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import com.jfoenix.controls.JFXButton?>
+<?import com.jfoenix.controls.JFXDialog?>
+<?import com.jfoenix.controls.JFXDialogLayout?>
 <?import javafx.scene.Group?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.shape.Rectangle?>
 
 <!-- Da der SceneBuilder mit einer eigenen JRE-Version 17 arbeitet, 
@@ -12,7 +16,7 @@ sollte der Wert des xmlns-Attributs stets geprüft und ggf. manuell
 von "http://javafx.com/javafx/17" auf "http://javafx.com/javafx/15.0.1" 
 angepasst werden, um Fehlermeldungen in Eclipse zu vermeiden. -->
 
-<AnchorPane prefHeight="720.0" prefWidth="1280.0" styleClass="root" stylesheets="@../css/level.css" xmlns="http://javafx.com/javafx/15.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="puf.frisbee.frontend.view.LevelView">
+<AnchorPane prefHeight="720.0" prefWidth="1280.0" styleClass="root" stylesheets="@../css/level.css" xmlns="http://javafx.com/javafx/15" xmlns:fx="http://javafx.com/fxml/1" fx:controller="puf.frisbee.frontend.view.LevelView">
    <children>
       <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#adbf93" height="120.0" layoutY="600.0" stroke="BLACK" strokeType="INSIDE" strokeWidth="0.0" width="1280.0" />
       <Group layoutX="161.0" layoutY="443.0">
@@ -38,5 +42,19 @@ angepasst werden, um Fehlermeldungen in Eclipse zu vermeiden. -->
          </children>
       </Group>
       <Label fx:id="labelCountdown" alignment="TOP_CENTER" layoutX="625.0" layoutY="55.0" />
+      <StackPane fx:id="modalRoot" layoutY="-1.0" prefHeight="722.0" prefWidth="1281.0">
+         <children>
+            <JFXDialog fx:id="levelSuccessDialog" prefHeight="313.0" prefWidth="433.0">
+               <JFXDialogLayout>
+                  <heading>
+                     <Label fx:id="labelLevelSuccess" />
+                  </heading>
+                  <actions>
+                     <JFXButton fx:id="buttonLevelContinue" onAction="#handleLevelContinueClicked" />
+                  </actions>
+               </JFXDialogLayout>
+            </JFXDialog>
+         </children>
+      </StackPane>
    </children>
 </AnchorPane>


### PR DESCRIPTION
Wenn die Zeit abläuft, dann wird ein Dialog gezeigt. Nach Bestätigung kommt man ins nächste Level (momentan nur an der Fensterbeschriftung sichtbar). Hier müssen wir uns später noch überlegen, wie wir das machen, evtl. nutzen wir auch den gleichen View"Controller" für verschiedene fxmls, damit wir nicht zuviel doppelten Code haben.

Ich habe für den Dialog Material UI genutzt (http://www.jfoenix.com/), deswegen die neue Abhängigkeit. Vielleicht können wir das als Basis nutzen und mit unserem CSS noch die Farben, etc anpassen? Der Dialog braucht einen StackPane als root, deswegen gibt es das als neues Element im fxml.

Außerdem gibts jetzt endlich das LevelModel Interface :) ich war beim Namen aber relativ einfallslos... `LevelModelInterface` fand ich jetzt auch nicht so überzeugend.

Bei dem Datendurchreichen zwischen Level, ViewModel und Model bin ich mir auch noch nicht ganz sicher (grad was das aktuelle Level betrifft), evtl. kann man da noch was vereinfachen, aber wir brauchen es halt auch in der View zum Laden des nächsten Bildschirms... vllt. ergibt sich da noch was besseres im Laufe der Entwicklung.

Hinweis:
Bei Intellij musste ich die IDE neu starten, damit die neue JFoenix Dependency geladen wurde.