### PR TITLE
Add player login validation at backend

### DIFF
--- a/frontend/src/main/java/puf/frisbee/frontend/model/Player.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Player.java
@@ -19,6 +19,13 @@ public interface Player {
     String getEmail();
 
     /**
+     * Returns the password of the player.
+     *
+     * @return the player password
+     */
+    String getPassword();
+
+    /**
      * Returns true if the player is logged in.
      *
      * @return true if player is logged in

--- a/frontend/src/main/java/puf/frisbee/frontend/model/PlayerModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/PlayerModel.java
@@ -4,6 +4,8 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 
@@ -24,6 +26,10 @@ public class PlayerModel implements Player {
         return email;
     }
 
+    @Override
+    public String getPassword() {
+        return password;
+    }
 
     @Override
     public boolean isLoggedIn() {
@@ -43,13 +49,12 @@ public class PlayerModel implements Player {
             this.password = password;
             this.isLoggedIn = true;
 
-
             ObjectMapper objectMapper = new ObjectMapper();
             String playerJson = objectMapper.writeValueAsString(this);
 
             HttpRequest request = HttpRequest.newBuilder()
-                    .uri(new URI("https://puf-frisbee-backend.herokuapp.com/api/players/register"))
-                    //                .uri(new URI("http://localhost:8080/api/players/register"))
+//                    .uri(new URI("https://puf-frisbee-backend.herokuapp.com/api/players/register"))
+                    .uri(new URI("http://localhost:8080/api/players/register"))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(playerJson))
                     .build();
@@ -59,7 +64,7 @@ public class PlayerModel implements Player {
                     .build()
                     .send(request, HttpResponse.BodyHandlers.ofString());
 
-            return response.statusCode() == 201 ? true : false;
+            return response.statusCode() == 201;
         }catch (Exception e){
             return false;
         }
@@ -67,7 +72,37 @@ public class PlayerModel implements Player {
 
     @Override
     public boolean login(String email, String password) {
-        return email.equals(this.email) && password.equals(this.password);
+
+        try {
+            String loginCredentials = "{\"email\":\"" + email + "\",\"password\":\"" + password  +"\"}";
+
+            HttpRequest request = HttpRequest.newBuilder()
+//                    .uri(new URI("https://puf-frisbee-backend.herokuapp.com/api/players/login"))
+                    .uri(new URI("http://localhost:8080/api/players/login"))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(loginCredentials))
+                    .build();
+
+            HttpResponse<String> response = HttpClient
+                    .newBuilder()
+                    .build()
+                    .send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200){
+
+                ObjectMapper objectMapper = new ObjectMapper();
+                Map<String, String> map = objectMapper.readValue(response.body(), Map.class);
+
+                this.name = map.get("name");
+                this.email = map.get("email");
+                this.isLoggedIn = true;
+                return true;
+            } else {
+                return false;
+            }
+        }catch (Exception e){
+            return false;
+        }
     }
 
     @Override


### PR DESCRIPTION
Player können sich nun im Backend registrieren und anschließend mit ihren Login-Credentials einloggen. Der Login sollte sowohl lokal als auch im Heroku-Backend funktionieren.

Den Getter für das Passwort brauchen wir doch, sonst serialisiert der ObjectMapper den Player ohne Passwort und es kommt dann keins im Backend an.