### PR TITLE
1. Use environment variable to configure request base url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# BACKEND_BASE_URL=https://puf-frisbee-backend.herokuapp.com/api
+BACKEND_BASE_URL=http://localhost:8080/api

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ target/
 
 # Apple Desktop Services Store
 .DS_Store
+
+# env
+**/.env

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ und bei "Import module from existing model" maven auswählen.
 Bei der Run Configuration kann dann `frontend` als Modul gewählt werden, der Pfad zur Main Application
 ist `puf.frisbee.frontend.StartApplication`.
 
+### Environment variables
+Für die Kommunikation mit dem Backend muss `.env.example` in ein neues File `.env` kopiert werden. 
+Je nachdem, ob mit dem lokalen oder deploytem Backend kommuniziert werden soll, müssen die Environment Variablen angepasst werden.
+
 ## Server starten
 TBD
 

--- a/frontend/pom.xml
+++ b/frontend/pom.xml
@@ -43,6 +43,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.13.0</version>
 		</dependency>
+		<dependency>
+			<groupId>io.github.cdimascio</groupId>
+			<artifactId>dotenv-java</artifactId>
+			<version>2.2.3</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/frontend/src/main/java/module-info.java
+++ b/frontend/src/main/java/module-info.java
@@ -5,8 +5,9 @@ module puf.frisbee.frontend {
 	requires javafx.base;
 	requires java.net.http;
 	requires com.fasterxml.jackson.databind;
+    requires dotenv.java;
 
-	opens puf.frisbee.frontend to javafx.fxml;
+    opens puf.frisbee.frontend to javafx.fxml;
 	exports puf.frisbee.frontend;
 
 	opens puf.frisbee.frontend.core to javafx.fxml;

--- a/frontend/src/main/java/puf/frisbee/frontend/model/PlayerModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/PlayerModel.java
@@ -7,14 +7,21 @@ import java.net.http.HttpResponse;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.cdimascio.dotenv.Dotenv;
 
 
 public class PlayerModel implements Player {
-
+    private String baseUrl;
     private String name;
     private String email;
     private String password;
     private boolean isLoggedIn = false;
+
+    public PlayerModel() {
+        // initialize base url for requests
+        Dotenv dotenv = Dotenv.load();
+        this.baseUrl = dotenv.get("BACKEND_BASE_URL");
+    }
 
     @Override
     public String getName() {
@@ -51,8 +58,7 @@ public class PlayerModel implements Player {
             String playerJson = objectMapper.writeValueAsString(this);
 
             HttpRequest request = HttpRequest.newBuilder()
-//                    .uri(new URI("https://puf-frisbee-backend.herokuapp.com/api/players/register"))
-                    .uri(new URI("http://localhost:8080/api/players/register"))
+                    .uri(new URI(this.baseUrl + "/players/register"))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(playerJson))
                     .build();
@@ -75,8 +81,7 @@ public class PlayerModel implements Player {
             String loginCredentials = "{\"email\":\"" + email + "\",\"password\":\"" + password  +"\"}";
 
             HttpRequest request = HttpRequest.newBuilder()
-//                    .uri(new URI("https://puf-frisbee-backend.herokuapp.com/api/players/login"))
-                    .uri(new URI("http://localhost:8080/api/players/login"))
+                    .uri(new URI(this.baseUrl + "/players/login"))
                     .header("Content-Type", "application/json")
                     .POST(HttpRequest.BodyPublishers.ofString(loginCredentials))
                     .build();
@@ -107,8 +112,7 @@ public class PlayerModel implements Player {
     public boolean updateName(String name) {
         try {
             HttpRequest request = HttpRequest.newBuilder()
-//                    .uri(new URI("https://puf-frisbee-backend.herokuapp.com/api/players/update-player-name/" + this.email))
-                    .uri(new URI("http://localhost:8080/api/players/update-player-name/" + this.email))
+                    .uri(new URI(this.baseUrl + "/players/update-player-name/" + this.email))
                     .header("Content-Type", "application/json")
                     .PUT(HttpRequest.BodyPublishers.ofString(name))
                     .build();


### PR DESCRIPTION
Zum testen im root folder ein neues `.env` file anlegen (siehe Readme) und mit der entsprechenden URL befüllen (lokal: `ACKEND_BASE_URL=http://localhost:8080/api`).

Registrierung, login und update des Namens sollten noch wie gewohnt funktionieren.