### PR TITLE
Save team data to backend when level is finished

### DIFF
--- a/frontend/src/main/java/puf/frisbee/frontend/model/LevelModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/LevelModel.java
@@ -3,7 +3,6 @@ package puf.frisbee.frontend.model;
 import puf.frisbee.frontend.core.Constants;
 
 public class LevelModel implements Level {	
-	// TODO: get this from the server
 	private final int maximumLevel = 3;
 	private int currentLevel = 0;
 
@@ -48,12 +47,12 @@ public class LevelModel implements Level {
 	@Override
 	public double getSceneBoundaryLeft() {
 		return this.sceneBoundaryLeft;
-	};
+	}
 
 	@Override
 	public double getSceneBoundaryRight() {
 		return Constants.SCENE_WIDTH - this.sceneBoundaryRight - Constants.CHARACTER_WIDTH;
-	};
+	}
 
 	@Override
 	public double getJumpHeight() {

--- a/frontend/src/main/java/puf/frisbee/frontend/model/Team.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Team.java
@@ -137,4 +137,11 @@ public interface Team {
 	 * @return true if a team for the player was found
 	 */
 	boolean getTeamForPlayer(Player player);
+
+	/**
+	 * Saves team data to backend and sets updated data in team model.
+	 *
+	 * @return true if saving was successful
+	 */
+	boolean saveTeamData();
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/model/TeamModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/TeamModel.java
@@ -207,6 +207,40 @@ public class TeamModel implements Team {
 		return false;
 	}
 
+	@Override
+	public boolean saveTeamData() {
+		try {
+			String requestBody = "{\"name\":\"" + this.name
+					+ "\",\"level\":" + this.level
+					+ ", \"score\":" + this.score
+					+ ", \"lives\":" + this.lives  + "}";
+
+			HttpRequest request = HttpRequest.newBuilder()
+					.uri(new URI(this.baseUrl + "/teams/update"))
+					.header("Content-Type", "application/json")
+					.PUT(HttpRequest.BodyPublishers.ofString(requestBody))
+					.build();
+
+			HttpResponse<String> response = HttpClient
+					.newBuilder()
+					.build()
+					.send(request, HttpResponse.BodyHandlers.ofString());
+
+			if (response.statusCode() == 201) {
+				ObjectMapper objectMapper = new ObjectMapper();
+				Team updatedTeam = objectMapper.readValue(response.body(), new TypeReference<>() {});
+				// set data to be sure to have the right data
+				setTeamData(updatedTeam);
+				return true;
+			}
+
+		} catch (Exception e) {
+			System.out.println(e.getMessage());
+		}
+
+		return false;
+	}
+
 	@JsonIgnore
 	private void setTeamData(Team team) {
 		this.id = team.getId();

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
@@ -455,6 +455,9 @@ public class GameViewModel {
 		this.teamModel.setLevel(this.levelModel.getCurrentLevel());
 		this.teamModel.setScore(this.labelScore.getValue());
 		this.teamModel.setLives(this.remainingLives);
+		// save to backend
+		this.teamModel.saveTeamData();
+		// reset countdown
 		this.gameModel.setCurrentCountdown(this.gameModel.getInitialCountdown());
 	}
 


### PR DESCRIPTION
Bei geschafftem Level oder Game Over werden die Daten im Backend gespeichert.

noch offen: wie wollen wir anzeigen, wenn das Speichern nicht erfolgreich war? (evtl. ein neues Ticket dann?)
weiterhin offen und für das nächste Ticket: Clean Up des Game View Models (https://github.com/wernerbreitenstein/Patterns-and-Frameworks/issues/143)