### PR TITLE
2. modify table styling via css

### DIFF
--- a/frontend/src/main/resources/puf/frisbee/frontend/css/tableview.css
+++ b/frontend/src/main/resources/puf/frisbee/frontend/css/tableview.css
@@ -13,13 +13,11 @@
 .table-view .column-header-background{
     -fx-background-color: rgba(0, 0, 0, 0.8);
     -fx-background-radius: 6px 6px 0px 0px;
-    -fx-background-insets: 0 12px 0 0;
     -fx-padding: 6px 0 6px 0;
 }
 
 .table-view .column-header {
     -fx-background-color: transparent;
-    -fx-background-insets: 0 12px 0 0;
 }
 
 .table-view .column-header .label {


### PR DESCRIPTION
Es passt, aber nicht ganz so, wie ich es gerne gestaltet hätte:
1. Wenn wir nicht mehr als 12 Einträg in der Highscore-Tabelle haben, wird keine Scrollbar angezeigt und alles sieht gut aus.
2. Ab dem 13. Eintrag erscheint die vertikale Scollbar und der Header wird so verlängert, dass er die Scrollbar mit in die Tabelle integriert. Finde ich nicht so gut, würde ich aber lassen. Das ist jetzt für mich im Moment zu vernachlässigen, sonst müsste man eine Abhängigkeit zur Anzahl der Tabelleneinträge implementieren und hierüber verschiedene CSS-Class selectors ansprechen. Das ist an dieser Stelle zu viel …