### PR TITLE
basic socket prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # BACKEND_BASE_URL=https://puf-frisbee-backend.herokuapp.com/api
 BACKEND_BASE_URL=http://localhost:8080/api
+SOCKET_IP=localhost
+SOCKET_PORT=9999

--- a/frontend/src/main/java/puf/frisbee/frontend/model/PlayerMotion.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/PlayerMotion.java
@@ -1,0 +1,5 @@
+package puf.frisbee.frontend.model;
+
+public enum PlayerMotion {
+    LEFT, RIGHT, UP
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/model/PlayerPosition.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/PlayerPosition.java
@@ -1,0 +1,5 @@
+package puf.frisbee.frontend.model;
+
+public enum PlayerPosition {
+    LEFT, RIGHT
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
@@ -1,0 +1,65 @@
+package puf.frisbee.frontend.network;
+
+import io.github.cdimascio.dotenv.Dotenv;
+import puf.frisbee.frontend.model.PlayerPosition;
+
+import java.io.*;
+import java.net.Socket;
+
+public class SocketClient {
+
+    private Socket socket;
+    private BufferedReader bufferedReader;
+    private BufferedWriter bufferedWriter;
+    private PlayerPosition playerPosition;
+
+    public SocketClient(){
+        Dotenv dotenv = Dotenv.load();
+        String socketIP = dotenv.get("SOCKET_IP");
+        int socketPort = Integer.parseInt((dotenv.get("SOCKET_PORT")));
+
+        try {
+            this.socket = new Socket(socketIP, socketPort);
+
+            InputStream input = this.socket.getInputStream();
+            OutputStream output = this.socket.getOutputStream();
+
+            this.bufferedWriter = new BufferedWriter(new OutputStreamWriter(output));
+            this.bufferedReader = new BufferedReader(new InputStreamReader(input));
+
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void setPlayerPosition(PlayerPosition playerPosition){
+        this.playerPosition = playerPosition;
+    }
+
+    public void sendMessageToServer(String message){
+        try {
+            this.bufferedWriter.write(message + "\n");
+            this.bufferedWriter.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    public String readMessageFromServer(){
+        try {
+            return this.bufferedReader.readLine();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+//    public static void main(String[] args) throws IOException {
+//
+//        SocketClient sc = new SocketClient();
+//        sc.sendMessageToServer("Hello this is a message from the client.\n");
+//        System.out.println(sc.readMessageFromServer());
+//    }
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketClientFactory.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketClientFactory.java
@@ -1,0 +1,21 @@
+package puf.frisbee.frontend.network;
+
+import puf.frisbee.frontend.model.PlayerPosition;
+
+public class SocketClientFactory {
+
+    private SocketClient socketClient;
+
+    public SocketClient getSocketClient() {
+        if (socketClient == null) {
+            socketClient = new SocketClient();
+        }
+
+        return socketClient;
+    }
+
+    public SocketClient getSocketClient(PlayerPosition playerPosition){
+        getSocketClient().setPlayerPosition(playerPosition);
+        return socketClient;
+    }
+}


### PR DESCRIPTION
Requires https://github.com/D1ANAmic/Patterns-and-Frameworks-Backend/pull/11


Das ist erst mal nur eine Idee davon, wie es funktionieren könnte. Aus irgendeinem Grund ist die Response vom Server sehr langsam und erscheint erst dann, wenn der Dialog für das nächste Level auftaucht. Aber auch das dauert wesentlich länger als der gesetzte CountDown.

Zum Testen: Spiel starten und mit dem linken Monster erst mal nach rechts laufen. Im Backend sollten dort da zahlreiche Messages ankommen. Danach dann nach links laufen. Jetzt friert das Spiel ein und nach unbestimmt langer Zeit ploppt der Dialog auf und im Frontend wird die Nachricht, die der Server zurückgegeben hat („LEFT“) ausgegeben.

* Die ganze Logik ist jetzt erst mal zum Testen in der startAnimation(). Das sollte dann, später noch aufgeräumt werden. Zuerst muss es aber funktionieren.
* Die überladene getSocketClient() in der SocketClientFactory wiederspricht ja so ziemlich der Idee des Singletons und führt außerdem dazu, dass bei dem Methodenaufruf ohne Argument, die Verbindung immer wieder neu aufgebaut wird (siehe characterLeft moves right) Gibt es eine andere Möglichkeit, die Playerposition direkt beim Erstellen des SocketClients zu übergeben?
* Mit der PlayerPosition passiert nocht nichts. Idealerweise sollte diese schon beim Aufbau der Connection übergeben werden – wie ist noch fraglich (im Header der SYN-Anfrage?)
* Warum hat Tony gesagt, wir müssen uns unser eigenes Protokoll überlegen? Darüber bin ich bisher noch an keiner Stelle gestolpert und die Nachrichten werden ja trotzdem übertragen.
