### PR TITLE
Only the own character can be moved now

### DIFF
--- a/frontend/src/main/java/puf/frisbee/frontend/core/Constants.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/core/Constants.java
@@ -12,11 +12,11 @@ public final class Constants {
     public static final double CHARACTER_RIGHT_CATCHING_ZONE_LEFT_Y = 106;
     public static final double CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_X = 157;
     public static final double CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_Y = 97;
-    public static final double CHARACTER_RIGHT_CATCHING_RADIUS = 21;
 
     public static final double CHARACTER_LEFT_CATCHING_ZONE_LEFT_X = 35;
     public static final double CHARACTER_LEFT_CATCHING_ZONE_LEFT_Y = 70;
     public static final double CHARACTER_LEFT_CATCHING_ZONE_RIGHT_X = 136;
     public static final double CHARACTER_LEFT_CATCHING_ZONE_RIGHT_Y = 76;
-    public static final double CHARACTER_LEFT_CATCHING_RADIUS = 21;
+
+    public static final double CHARACTER_CATCHING_RADIUS = 21;
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/model/CharacterType.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/CharacterType.java
@@ -1,0 +1,9 @@
+package puf.frisbee.frontend.model;
+
+/**
+ * The character types that exist - left or right.
+ */
+public enum CharacterType {
+    LEFT,
+    RIGHT
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/model/PlayerModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/PlayerModel.java
@@ -166,4 +166,11 @@ public class PlayerModel implements Player {
         this.password = password;
         return false;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        Player otherPlayer = (Player) o;
+        // Players are the same, if email matches
+        return this.email.equals(otherPlayer.getEmail());
+    }
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/model/Team.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Team.java
@@ -163,4 +163,11 @@ public interface Team {
 	 * Resets team data in team model.
 	 */
 	void resetTeamData();
+
+	/**
+	 * Returns character type of the player.
+	 *
+	 * @return left or right
+	 */
+	CharacterType getOwnCharacterType();
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/model/TeamModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/TeamModel.java
@@ -16,6 +16,8 @@ public class TeamModel implements Team {
 	private final String baseUrl;
 	@JsonIgnore
 	private boolean teamIsSet;
+	@JsonIgnore
+	private CharacterType ownCharacterType;
 
 	private int id;
 	private String name;
@@ -173,6 +175,9 @@ public class TeamModel implements Team {
 				Team joinedTeam = objectMapper.readValue(response.body(), new TypeReference<>() {});
 				setTeamData(joinedTeam);
 
+				// also set own character type for the game later, depending on the position in the team
+				this.ownCharacterType = joinedTeam.getPlayerLeft().equals(player) ? CharacterType.LEFT : CharacterType.RIGHT;
+
 				return true;
 			}
 
@@ -209,6 +214,10 @@ public class TeamModel implements Team {
 				// set data of first found team for this player after sorting alphabetically
 				teams.sort(Comparator.comparing(Team::getName));
 				setTeamData(teams.get(0));
+
+				// also set own character type for the game later, depending on the position in the team
+				this.ownCharacterType = teams.get(0).getPlayerLeft().equals(player) ? CharacterType.LEFT : CharacterType.RIGHT;
+
 				return true;
 			}
 
@@ -282,5 +291,11 @@ public class TeamModel implements Team {
 		this.active = team.getActive();
 
 		this.teamIsSet = true;
+	}
+
+	@JsonIgnore
+	@Override
+	public CharacterType getOwnCharacterType() {
+		return this.ownCharacterType;
 	}
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/view/GameView.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/view/GameView.java
@@ -81,26 +81,17 @@ public class GameView {
 	@FXML
 	private void handleKeyPressed(KeyEvent event) {
 		switch (event.getCode()) {
-		case LEFT -> this.gameViewModel.moveCharacterLeft("right");
-		case RIGHT -> this.gameViewModel.moveCharacterRight("right");
-		case UP -> this.gameViewModel.jumpCharacter("right");
-
-		// TODO: this will be removed in the future, the second character position will probably come via websocket
-		case A -> this.gameViewModel.moveCharacterLeft("left");
-		case D -> this.gameViewModel.moveCharacterRight("left");
-		case W -> this.gameViewModel.jumpCharacter("left");
+		case LEFT -> this.gameViewModel.moveCharacterLeft();
+		case RIGHT -> this.gameViewModel.moveCharacterRight();
+		case UP -> this.gameViewModel.jumpCharacter();
 		}
 	}
 
 	@FXML
 	private void handleKeyReleased(KeyEvent event) {
 		switch (event.getCode()) {
-		case LEFT -> this.gameViewModel.stopCharacterMoveLeft("right");
-		case RIGHT -> this.gameViewModel.stopCharacterMoveRight("right");
-
-		// TODO: this will be removed in the future, the second character position will probably come via websocket
-		case A -> this.gameViewModel.stopCharacterMoveLeft("left");
-		case D -> this.gameViewModel.stopCharacterMoveRight("left");
+		case LEFT -> this.gameViewModel.stopCharacterMoveLeft();
+		case RIGHT -> this.gameViewModel.stopCharacterMoveRight();
 		}
 	}
 
@@ -120,12 +111,6 @@ public class GameView {
 	private void handleButtonGameSuccessQuit(ActionEvent event) {
 		this.gameViewModel.saveAfterGameSucceeded();
 		this.viewHandler.openStartView();
-	}
-
-	@FXML
-	private void handleButtonGameOverContinue(ActionEvent event) {
-		this.gameViewModel.saveAfterGameOver();
-		this.viewHandler.openGameView();
 	}
 
 	@FXML

--- a/frontend/src/main/java/puf/frisbee/frontend/view/WaitingView.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/view/WaitingView.java
@@ -4,6 +4,7 @@ import javafx.animation.*;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
+import javafx.scene.control.Label;
 import javafx.scene.image.ImageView;
 import javafx.util.Duration;
 import puf.frisbee.frontend.core.ViewHandler;
@@ -31,6 +32,9 @@ public class WaitingView {
     @FXML
     private Button buttonStart;
 
+    @FXML
+    private Label playerGreeting;
+
     private WaitingViewModel waitingViewModel;
     private ViewHandler viewHandler;
 
@@ -44,6 +48,8 @@ public class WaitingView {
 
         this.topPanelController.init(waitingViewModel, viewHandler);
         this.bottomPanelController.init(waitingViewModel, viewHandler);
+
+        this.playerGreeting.textProperty().bind(waitingViewModel.getLabelPlayerGreetingProperty());
 
         this.startFrisbeeTransition();
     }

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
@@ -102,7 +102,7 @@ public class GameViewModel {
 		this.labelScore = new SimpleIntegerProperty();
 
 		this.ownCharacter = teamModel.getOwnCharacterType();
-		initializeCharacterData();
+		initializeCharacterPositions();
 
 		this.isCharacterMovingLeft = false;
 		this.isCharacterMovingRight = false;
@@ -126,35 +126,28 @@ public class GameViewModel {
 	}
 
 	// set initial positions and catching zones for players, left or right depends on the own character type
-	private void initializeCharacterData() {
-		// for better readability, code is duplicated
-		if (this.ownCharacter == CharacterType.LEFT) {
-			// own character is left
-			this.ownCharacterXPosition = new SimpleDoubleProperty(levelModel.getInitialCharacterLeftXPosition());
-			this.ownCharacterCatchingZoneLeftX = Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_X;
-			this.ownCharacterCatchingZoneLeftY = Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_Y;
-			this.ownCharacterCatchingZoneRightX = Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_X;
-			this.ownCharacterCatchingZoneRightY = Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_Y;
-			// so other character is right
-			this.otherCharacterXPosition = new SimpleDoubleProperty(levelModel.getInitialCharacterRightXPosition());
-			this.otherCharacterCatchingZoneLeftX = Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_X;
-			this.otherCharacterCatchingZoneLeftY = Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_Y;
-			this.otherCharacterCatchingZoneRightX = Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_X;
-			this.otherCharacterCatchingZoneRightY = Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_Y;
-		} else {
-			// own character is right
-			this.ownCharacterXPosition = new SimpleDoubleProperty(levelModel.getInitialCharacterRightXPosition());
-			this.ownCharacterCatchingZoneLeftX = Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_X;
-			this.ownCharacterCatchingZoneLeftY = Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_Y;
-			this.ownCharacterCatchingZoneRightX = Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_X;
-			this.ownCharacterCatchingZoneRightY = Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_Y;
-			// so other character is left
-			this.otherCharacterXPosition = new SimpleDoubleProperty(levelModel.getInitialCharacterLeftXPosition());
-			this.otherCharacterCatchingZoneLeftX = Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_X;
-			this.otherCharacterCatchingZoneLeftY = Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_Y;
-			this.otherCharacterCatchingZoneRightX = Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_X;
-			this.otherCharacterCatchingZoneRightY = Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_Y;
-		}
+	private void initializeCharacterPositions() {
+		this.ownCharacterXPosition = new SimpleDoubleProperty(this.ownCharacter == CharacterType.LEFT ?
+				levelModel.getInitialCharacterLeftXPosition() : levelModel.getInitialCharacterRightXPosition());
+		this.ownCharacterCatchingZoneLeftX = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_X : Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_X;
+		this.ownCharacterCatchingZoneLeftY = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_Y :  Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_Y;
+		this.ownCharacterCatchingZoneRightX = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_X : Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_X;
+		this.ownCharacterCatchingZoneRightY = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_Y : Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_Y;
+
+		this.otherCharacterXPosition = new SimpleDoubleProperty(this.ownCharacter == CharacterType.LEFT ?
+				levelModel.getInitialCharacterRightXPosition() : levelModel.getInitialCharacterLeftXPosition());
+		this.otherCharacterCatchingZoneLeftX = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_X : Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_X;
+		this.otherCharacterCatchingZoneLeftY = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_RIGHT_CATCHING_ZONE_LEFT_Y : Constants.CHARACTER_LEFT_CATCHING_ZONE_LEFT_Y;
+		this.otherCharacterCatchingZoneRightX = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_X : Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_X;
+		this.otherCharacterCatchingZoneRightY = this.ownCharacter == CharacterType.LEFT ?
+				Constants.CHARACTER_RIGHT_CATCHING_ZONE_RIGHT_Y : Constants.CHARACTER_LEFT_CATCHING_ZONE_RIGHT_Y;
 
 		// y position is the same for both characters
 		this.ownCharacterYPosition = new SimpleDoubleProperty(levelModel.getInitialCharacterYPosition());

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
@@ -309,9 +309,7 @@ public class GameViewModel {
 		this.counter = 0;
 	}
 
-	// this function will be used when own and when other character throws frisbee and takes different parameters
 	private void frisbeeMove() {
-		// frisbee
 		double frisbeeYDirection;
 		double t;
 

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/WaitingViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/WaitingViewModel.java
@@ -37,9 +37,10 @@ public class WaitingViewModel {
         this.labelLevel = new SimpleStringProperty();
         this.labelCountdown = new SimpleStringProperty();
         this.labelScore = new SimpleIntegerProperty();
-        this.labelPlayerGreeting = new SimpleStringProperty(
-                teamModel.getOwnCharacterType() == CharacterType.LEFT ? "PLEASE WAIT PLAYER LEFT." : "PLEASE WAIT PLAYER RIGHT."
-        );
+        String greeting = "Please wait, player " +
+                (teamModel.getOwnCharacterType() == CharacterType.LEFT ? "left" : "right") +
+                ". The second freak will show up soon.";
+        this.labelPlayerGreeting = new SimpleStringProperty(greeting);
     }
 
     public BooleanProperty getShowLevel01BackgroundImageProperty() {

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/WaitingViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/WaitingViewModel.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 
 public class WaitingViewModel {
     private Game gameModel;
-    private Level levelModel;
     private Team teamModel;
 
     private BooleanProperty showLevel01BackgroundImage;
@@ -17,13 +16,12 @@ public class WaitingViewModel {
     private StringProperty labelLevel;
     private IntegerProperty labelScore;
     private StringProperty labelCountdown;
-    private IntegerProperty labelLives;
+    private StringProperty labelPlayerGreeting;
 
     private ArrayList<BooleanProperty> teamLivesHidden;
 
     public WaitingViewModel(Game gameModel, Level levelModel, Team teamModel) {
         this.gameModel = gameModel;
-        this.levelModel = levelModel;
         this.teamModel = teamModel;
         this.teamLivesHidden = new ArrayList<>(5);
         for (int i = 0; i < 5; i++) {
@@ -39,7 +37,9 @@ public class WaitingViewModel {
         this.labelLevel = new SimpleStringProperty();
         this.labelCountdown = new SimpleStringProperty();
         this.labelScore = new SimpleIntegerProperty();
-        this.labelLives = new SimpleIntegerProperty();
+        this.labelPlayerGreeting = new SimpleStringProperty(
+                teamModel.getOwnCharacterType() == CharacterType.LEFT ? "PLEASE WAIT PLAYER LEFT." : "PLEASE WAIT PLAYER RIGHT."
+        );
     }
 
     public BooleanProperty getShowLevel01BackgroundImageProperty() {
@@ -85,5 +85,9 @@ public class WaitingViewModel {
 
     public BooleanProperty getTeamLivesHiddenProperty(int lifeIndex) {
         return this.teamLivesHidden.get(lifeIndex);
+    }
+
+    public StringProperty getLabelPlayerGreetingProperty() {
+        return this.labelPlayerGreeting;
     }
 }

--- a/frontend/src/main/resources/puf/frisbee/frontend/view/WaitingView.fxml
+++ b/frontend/src/main/resources/puf/frisbee/frontend/view/WaitingView.fxml
@@ -51,15 +51,6 @@
                         <Insets bottom="20.0" />
                      </VBox.margin>
                   </Label>
-                  <Label stylesheets="@../css/main.css" text="The second freak will show up soon.">
-                     <styleClass>
-                        <String fx:value="dialog-text" />
-                        <String fx:value="dialog-h1" />
-                     </styleClass>
-                     <VBox.margin>
-                        <Insets bottom="20.0" />
-                     </VBox.margin>
-                  </Label>
                   <VBox alignment="CENTER">
                      <children>
                         <ImageView fx:id="frisbee" fitHeight="90.0" fitWidth="90.0" pickOnBounds="true" preserveRatio="true">

--- a/frontend/src/main/resources/puf/frisbee/frontend/view/WaitingView.fxml
+++ b/frontend/src/main/resources/puf/frisbee/frontend/view/WaitingView.fxml
@@ -42,6 +42,15 @@
                         <Insets bottom="40.0" />
                      </VBox.margin>
                   </Label>
+                  <Label fx:id="playerGreeting" stylesheets="@../css/main.css">
+                     <styleClass>
+                        <String fx:value="dialog-text" />
+                        <String fx:value="dialog-h1" />
+                     </styleClass>
+                     <VBox.margin>
+                        <Insets bottom="20.0" />
+                     </VBox.margin>
+                  </Label>
                   <Label stylesheets="@../css/main.css" text="The second freak will show up soon.">
                      <styleClass>
                         <String fx:value="dialog-text" />


### PR DESCRIPTION
Dieser Teil beschäftigt sich mit der Bewegung der Character.
Mit den Pfeiltasten kann jetzt nur der eigene Character bewegt werden. Zum testen zwei Player erstellen, die im gleichen Team sind. Der eine Player bewegt mit den Pfeiltasten den linken Character, nach Logout und Login des zweiten Players, kann dieser den rechten Character bewegen.
Auf der Waiting View wird ausserdem mit einer Begrüssung angezeigt, welchen Character der Player hat.

Jump für den "empfangenen" Character  ist noch nicht implementiert.


---
According to the position in the team, the left or right character
can be moved with the arrow keys.
The character is also greeted in the waiting view.