### PR TITLE
Send movement data to socket now as json

### DIFF
--- a/frontend/src/main/java/module-info.java
+++ b/frontend/src/main/java/module-info.java
@@ -22,4 +22,7 @@ module puf.frisbee.frontend {
 
 	opens puf.frisbee.frontend.view to javafx.fxml;
 	exports puf.frisbee.frontend.view;
+
+	// needed for jackson databind
+	exports puf.frisbee.frontend.network;
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/core/ModelFactory.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/core/ModelFactory.java
@@ -86,7 +86,7 @@ public class ModelFactory {
 	 */
 	public Character getCharacterModel() {
 		if (characterModel == null) {
-			characterModel = new CharacterModel(socketClientFactory.getSocketClient());
+			characterModel = new CharacterModel(socketClientFactory.getSocketClient(), this.getTeamModel());
 		}
 
 		return characterModel;

--- a/frontend/src/main/java/puf/frisbee/frontend/model/Character.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Character.java
@@ -1,5 +1,7 @@
 package puf.frisbee.frontend.model;
 
+import puf.frisbee.frontend.network.SocketRequestType;
+
 import java.beans.PropertyChangeListener;
 
 public interface Character {
@@ -15,7 +17,8 @@ public interface Character {
 
     /**
      * Add listener that can be used to notify subscribers when e.g. a character should be moved.
+     * @param type type of event that should be listened to
      * @param listener listener that should be added to Character
      */
-    void addPropertyChangeListener(PropertyChangeListener listener);
+    void addPropertyChangeListener(SocketRequestType type, PropertyChangeListener listener);
 }

--- a/frontend/src/main/java/puf/frisbee/frontend/model/Character.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Character.java
@@ -4,13 +4,17 @@ import java.beans.PropertyChangeListener;
 
 public interface Character {
     /**
-     * Send a message to socket as soon as own position is moved, so the other client knows
+     * Sends a message to the server to initialize a socket session for the team of this character.
+     */
+    void init();
+    /**
+     * Send a message to socket as soon as own position is moved, so the other client knows.
      * @param direction in which the character is moved
      */
     void moveOwnCharacter(MovementDirection direction);
 
     /**
-     * Add listener that can be used to notify subscribers when e.g. a character should be moved
+     * Add listener that can be used to notify subscribers when e.g. a character should be moved.
      * @param listener listener that should be added to Character
      */
     void addPropertyChangeListener(PropertyChangeListener listener);

--- a/frontend/src/main/java/puf/frisbee/frontend/model/CharacterModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/CharacterModel.java
@@ -6,18 +6,25 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 
-// TODO: create interface
 public class CharacterModel implements Character {
     SocketClient socketClient;
+    Team teamModel;
     private PropertyChangeSupport support;
 
-    public CharacterModel(SocketClient socketClient) {
+    public CharacterModel(SocketClient socketClient, Team teamModel) {
         this.socketClient = socketClient;
+        this.teamModel = teamModel;
         // add listener to socket income changes
         socketClient.addPropertyChangeListener(this::getOtherCharacterMovement);
 
         // create own support to notify models
         support = new PropertyChangeSupport(this);
+    }
+
+    // tell the server we are connected with our team
+    @Override
+    public void init() {
+        this.socketClient.sendInitToServer(this.teamModel.getName());
     }
 
     // send message to socket as soon as own position is moved, so the other client knows

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
@@ -62,6 +62,11 @@ public class SocketClient {
         }
     }
 
+    public void sendInitToServer(String teamName) {
+        SocketRequest request = new SocketRequest(SocketRequestType.INIT, teamName);
+        sendToServer(request);
+    }
+
     public void sendMovementToServer(MovementDirection direction){
         String directionString = direction == MovementDirection.LEFT ? "left" : "right";
         SocketRequest request = new SocketRequest(SocketRequestType.MOVE, directionString);

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
@@ -51,7 +51,7 @@ public class SocketClient {
                 ObjectMapper objectMapper = new ObjectMapper();
                 SocketRequest response = objectMapper.readValue(receivedJsonString, new TypeReference<>() {
                 });
-                // TODO: think about property name and maybe only subscribe listener to needed changes
+                // add request type as name so the character model knows how to react on what
                 support.firePropertyChange(response.getRequestType().name(), null, response.getValue());
             }
 
@@ -68,8 +68,7 @@ public class SocketClient {
     }
 
     public void sendMovementToServer(MovementDirection direction){
-        String directionString = direction == MovementDirection.LEFT ? "left" : "right";
-        SocketRequest request = new SocketRequest(SocketRequestType.MOVE, directionString);
+        SocketRequest request = new SocketRequest(SocketRequestType.MOVE, direction.name());
         sendToServer(request);
     }
 
@@ -84,8 +83,9 @@ public class SocketClient {
         }
     }
 
-    public void addPropertyChangeListener(PropertyChangeListener listener) {
-        support.addPropertyChangeListener(listener);
+    // add listener for defined types
+    public void addPropertyChangeListener(SocketRequestType type, PropertyChangeListener listener) {
+        support.addPropertyChangeListener(type.name(), listener);
     }
 
 

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
@@ -1,5 +1,7 @@
 package puf.frisbee.frontend.network;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.cdimascio.dotenv.Dotenv;
 import puf.frisbee.frontend.model.MovementDirection;
 
@@ -45,11 +47,12 @@ public class SocketClient {
 
             // listen for requests from the server, notify listeners when request came in
             while(threadIsRunning) {
-                // TODO: we need a shared object between client and server, like the request object
-                // TODO: otherwise we can not differentiate between characters and objects
-                String request = (String) inFromServer.readObject();
+                String receivedJsonString = (String) inFromServer.readObject();
+                ObjectMapper objectMapper = new ObjectMapper();
+                SocketRequest response = objectMapper.readValue(receivedJsonString, new TypeReference<>() {
+                });
                 // TODO: think about property name and maybe only subscribe listener to needed changes
-                support.firePropertyChange("MOVE", null, request);
+                support.firePropertyChange(response.getRequestType().name(), null, response.getValue());
             }
 
             inFromServer.close();
@@ -60,17 +63,18 @@ public class SocketClient {
     }
 
     public void sendMovementToServer(MovementDirection direction){
-        // TODO: use real objects with character, team, ... right now only string is working
         String directionString = direction == MovementDirection.LEFT ? "left" : "right";
-        sendToServer(directionString);
+        SocketRequest request = new SocketRequest(SocketRequestType.MOVE, directionString);
+        sendToServer(request);
     }
 
-    private void sendToServer(String request) {
+    private void sendToServer(SocketRequest request) {
         try {
-            // TODO: we need a shared object between client and server, like the request object
-            // right now we can only send the direction
-            outToServer.writeObject(request);
-        } catch (IOException e) {
+            ObjectMapper mapper = new ObjectMapper();
+            String jsonString = mapper.writeValueAsString(request);
+            outToServer.writeObject(jsonString);
+        } catch (Exception e) {
+            e.printStackTrace();
             support.firePropertyChange("ERROR", null, "Connection lost, restart program");
         }
     }

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketRequest.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketRequest.java
@@ -1,0 +1,32 @@
+package puf.frisbee.frontend.network;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(as = SocketRequest.class)
+public class SocketRequest {
+    private SocketRequestType requestType;
+    private String value;
+
+    public SocketRequest(){}
+
+    public SocketRequest(SocketRequestType requestType, String value) {
+        this.requestType = requestType;
+        this.value = value;
+    }
+
+    public SocketRequestType getRequestType() {
+        return requestType;
+    }
+
+    public void setRequestType(SocketRequestType requestType) {
+        this.requestType = requestType;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketRequestType.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketRequestType.java
@@ -1,0 +1,12 @@
+package puf.frisbee.frontend.network;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum SocketRequestType {
+    @JsonProperty("INIT")
+    INIT,
+    @JsonProperty("MOVE")
+    MOVE,
+    @JsonProperty("THROW")
+    THROW;
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketRequestType.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketRequestType.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public enum SocketRequestType {
     @JsonProperty("INIT")
     INIT,
+    @JsonProperty("READY")
+    READY,
     @JsonProperty("MOVE")
     MOVE,
     @JsonProperty("THROW")

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
@@ -121,6 +121,9 @@ public class GameViewModel {
 		// helper for the frisbee y position
 		this.isHighestFrisbeePointReached = false;
 
+		// TODO: move this to waiting view in the future
+		this.characterModel.init();
+
 		this.startCountdown();
 		this.startAnimation();
 	}

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/GameViewModel.java
@@ -7,6 +7,7 @@ import javafx.util.Duration;
 import puf.frisbee.frontend.core.Constants;
 import puf.frisbee.frontend.model.*;
 import puf.frisbee.frontend.model.Character;
+import puf.frisbee.frontend.network.SocketRequestType;
 import puf.frisbee.frontend.utils.Calculations;
 
 import java.beans.PropertyChangeEvent;
@@ -77,7 +78,7 @@ public class GameViewModel {
 		this.teamModel = teamModel;
 		this.characterModel = characterModel;
 		// executeActionsReceivedFromSocket is called when character model triggers change
-		characterModel.addPropertyChangeListener(this::executeCharacterActionsReceivedFromSocket);
+		characterModel.addPropertyChangeListener(SocketRequestType.MOVE, this::executeOtherCharacterMovement);
 
 		this.remainingLives = teamModel.getLives();
 		this.teamLivesHidden = new ArrayList<>(5);
@@ -208,7 +209,7 @@ public class GameViewModel {
 	}
 
 	// this function is called when a character action came in from the server
-	private void executeCharacterActionsReceivedFromSocket(PropertyChangeEvent event) {
+	private void executeOtherCharacterMovement(PropertyChangeEvent event) {
 		MovementDirection movementDirection = (MovementDirection) event.getNewValue();
 		if (movementDirection == MovementDirection.LEFT) {
 			// update in javafx thread
@@ -220,20 +221,17 @@ public class GameViewModel {
 			Platform.runLater(() -> otherCharacterXPosition.setValue(otherCharacterXPosition.getValue() + gameModel.getCharacterSpeed()));
 		}
 
-		// TODO: implement correctly
 		if (movementDirection == MovementDirection.UP) {
 			// update in javafx thread
 			Platform.runLater(() -> this.otherCharacterYPosition.setValue(this.otherCharacterYPosition.getValue() - this.levelModel.getJumpHeight()));
 		}
-
-		// TODO: get throw data from socket
-		// use functionality from socketDummyFunctionTriggeredByClick then, which is now triggered by click (and because of that external)
 	}
 
-	// TODO: remove later and add function code to executeCharacterActionsReceivedFromSocket
+	// TODO: remove later and add function code to listener function of character throw property change event
+	// use functionality from socketDummyFunctionTriggeredByClick then, which is now triggered by click (and because of that external)
 	private void socketFrisbeeDummyFunctionTriggeredByClick() {
 		this.resetThrowParameter();
-		// get throw data from socket, for now just improvise
+		// TODO: get throw data from socket, for now just improvise
 		this.frisbeeSpeedX = Math.random() * 8 + 2;
 		this.frisbeeSpeedY = Math.random() * 2 + 0.2;
 		this.counter = 0;
@@ -478,6 +476,7 @@ public class GameViewModel {
 	public void jumpCharacter() {
 		if (isCharacterAllowedToJump()) {
 			this.ownCharacterYPosition.setValue(this.ownCharacterYPosition.getValue() - this.levelModel.getJumpHeight());
+			this.characterModel.moveOwnCharacter(MovementDirection.UP);
 		}
 	}
 	


### PR DESCRIPTION
Die Daten werden jetzt als JSON String geschickt (und beim zurückholen wieder entpackt).
Getestet werden kann mit dem branch `client-json-request-tests` im Backend. Der gibt grad nur zurück, was hinkommt.

Das bedeutet für den Client, dass sich der andere Character in die gleiche Richtung bewegt wie der eigene.
Ausserdem wird jetzt auch mitgehüpft :)