### PR TITLE
Fix inconsistencies in game play

### DIFF
--- a/frontend/src/main/java/puf/frisbee/frontend/model/Character.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/Character.java
@@ -24,10 +24,22 @@ public interface Character {
     void startGame();
 
     /**
-     * Sends a message to the server to notify the other client to stop the
+     * Sends a message to the server to notify the other client to pause the
      * game.
      */
-    void stopGame();
+    void pauseGame();
+
+    /**
+     * Sends a message to the server to notify the other client to resume the
+     * game.
+     */
+    void resumeGame();
+
+    /**
+     * Sends a message to the server to notify the other client to continue the
+     * game, e.g. after a level success dialog.
+     */
+    void continueGame();
 
     /**
      * Send a message to socket as soon as own position is moved, so the

--- a/frontend/src/main/java/puf/frisbee/frontend/model/CharacterModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/model/CharacterModel.java
@@ -1,5 +1,6 @@
 package puf.frisbee.frontend.model;
 
+import puf.frisbee.frontend.network.GameRunningStatus;
 import puf.frisbee.frontend.network.SocketClient;
 import puf.frisbee.frontend.network.SocketRequestType;
 
@@ -37,7 +38,7 @@ public class CharacterModel implements Character {
                 this::forwardNotificationAsBoolean);
         // add listener to game status
         socketClient.addPropertyChangeListener(SocketRequestType.GAME_RUNNING,
-                this::forwardNotificationAsBoolean);
+                this::forwardNotification);
         // add listener to socket income changes for movement
         socketClient.addPropertyChangeListener(SocketRequestType.MOVE,
                 this::forwardNotification);
@@ -65,14 +66,22 @@ public class CharacterModel implements Character {
 
     @Override
     public void startGame() {
-        // tell the other client the game has started
-        this.socketClient.sendGameRunningToServer(true);
+        this.socketClient.sendGameRunningStatusToServer(GameRunningStatus.START);
     }
 
     @Override
-    public void stopGame() {
-        // tell the other client the game has stopped
-        this.socketClient.sendGameRunningToServer(false);
+    public void pauseGame() {
+        this.socketClient.sendGameRunningStatusToServer(GameRunningStatus.PAUSE);
+    }
+
+    @Override
+    public void continueGame() {
+        this.socketClient.sendGameRunningStatusToServer(GameRunningStatus.CONTINUE);
+    }
+
+    @Override
+    public void resumeGame() {
+        this.socketClient.sendGameRunningStatusToServer(GameRunningStatus.RESUME);
     }
 
     @Override

--- a/frontend/src/main/java/puf/frisbee/frontend/network/GameRunningStatus.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/GameRunningStatus.java
@@ -1,0 +1,20 @@
+package puf.frisbee.frontend.network;
+
+public enum GameRunningStatus {
+    /**
+     * Start the game.
+     */
+    START,
+    /**
+     * Pause the game.
+     */
+    PAUSE,
+    /**
+     * Resume after pause.
+     */
+    RESUME,
+    /**
+     * Continue, e.g. after a level is done.
+     */
+    CONTINUE,
+}

--- a/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/network/SocketClient.java
@@ -104,6 +104,9 @@ public class SocketClient {
                     case THROW -> propertyValue =
                             FrisbeeParameter.stringToObject(
                                     response.getValue());
+                    case GAME_RUNNING -> propertyValue =
+                            mapGameRunningStringToGameRunningStatus(
+                            response.getValue());
                     // default is we are just passing the value through
                     default -> propertyValue = response.getValue();
                 }
@@ -144,6 +147,30 @@ public class SocketClient {
     }
 
     /**
+     * Helper method to convert game running strings from the socket to enums.
+     *
+     * @param gameRunning status as string
+     * @return status as enum
+     */
+    private GameRunningStatus mapGameRunningStringToGameRunningStatus(
+            String gameRunning) {
+        if (gameRunning.equals(GameRunningStatus.START.name())) {
+            return GameRunningStatus.START;
+        }
+        if (gameRunning.equals(GameRunningStatus.PAUSE.name())) {
+            return GameRunningStatus.PAUSE;
+        }
+        if (gameRunning.equals(GameRunningStatus.RESUME.name())) {
+            return GameRunningStatus.RESUME;
+        }
+        if (gameRunning.equals(GameRunningStatus.CONTINUE.name())) {
+            return GameRunningStatus.CONTINUE;
+        }
+
+        return null;
+    }
+
+    /**
      * Transfers the team name to the server.
      *
      * @param teamName name of the team
@@ -164,14 +191,13 @@ public class SocketClient {
     }
 
     /**
-     * Sends GAME_RUNNING to the server.
+     * Sends GAME_RUNNING with a value to the server.
      *
-     * @param value true if game is running, false if not
+     * @param value the value of game running
      */
-    public void sendGameRunningToServer(boolean value) {
-        String status = value ? "true" : "false";
+    public void sendGameRunningStatusToServer(GameRunningStatus value) {
         SocketRequest request = new SocketRequest(
-                SocketRequestType.GAME_RUNNING, status);
+                SocketRequestType.GAME_RUNNING, value.name());
         sendToServer(request);
     }
 

--- a/frontend/src/main/java/puf/frisbee/frontend/view/GameView.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/view/GameView.java
@@ -196,9 +196,13 @@ public class GameView {
      */
     @FXML
     private void handleButtonLevelSuccessContinue(ActionEvent event) {
-        this.gameViewModel.saveAfterLevelSucceeded();
-        this.gameViewModel.continueGame();
-        this.viewHandler.openGameView();
+        boolean saveSuccessful = this.gameViewModel.saveAfterLevelSucceeded();
+        // wait for save before doing anything else, so the other player can
+        // sync
+        if (saveSuccessful) {
+            this.gameViewModel.continueGame();
+            this.viewHandler.openGameView();
+        }
     }
 
     /**
@@ -254,7 +258,7 @@ public class GameView {
      */
     @FXML
     private void handleButtonQuitGameContinue(ActionEvent event) {
-        this.gameViewModel.continueGame();
+        this.gameViewModel.resumeGame();
         this.viewHandler.openGameView();
     }
 

--- a/frontend/src/main/java/puf/frisbee/frontend/viewmodel/WaitingViewModel.java
+++ b/frontend/src/main/java/puf/frisbee/frontend/viewmodel/WaitingViewModel.java
@@ -4,6 +4,7 @@ import javafx.application.Platform;
 import javafx.beans.property.*;
 import puf.frisbee.frontend.model.*;
 import puf.frisbee.frontend.model.Character;
+import puf.frisbee.frontend.network.GameRunningStatus;
 import puf.frisbee.frontend.network.SocketRequestType;
 
 import java.beans.PropertyChangeEvent;
@@ -147,13 +148,13 @@ public class WaitingViewModel {
 
     /**
      * This method is called when the game running status in the character model
-     * is true.
+     * is set to start.
      * It notifies all subscribers of the waiting view model support.
      *
      * @param event property change event
      */
     private void changeRedirectToGameProperty(PropertyChangeEvent event) {
-        if ((boolean) event.getNewValue()) {
+        if (event.getNewValue() == GameRunningStatus.START) {
             // notify view like this since the redirect is not an element
             this.support.firePropertyChange("running", null, true);
         }


### PR DESCRIPTION
Achtung! Dieser PR basiert auf https://github.com/wernerbreitenstein/Patterns-and-Frameworks/pull/245, dieser sollte also zuerst gemerged werden. 
Vor dem Merge dieses PRs muss der Zielbranch angepasst werden.

Wenn es bessere Vorschläge gibt für den Namen des GameRunningStatus Enums, dann ändere ich das gerne - mir ist grad nichts besseres eingefallen.


The game running status is not only true or false no, but indicates the triggered action.
This way it is easier to determine the needed action that should be executed, when the game running status change comes in from the socket.

Also we are waiting with continuing to the next level now until the save is done to make sure, the other client also gets the correct changes.

The team model is now updated with the newest data as soon as pause is clicked - the client that is receiving the socket connection update does the same. This way, the correct data should be loaded when the game view is reloaded on pause continue.